### PR TITLE
Prüfe testabdeckung und schlage verbesserungen vor

### DIFF
--- a/metamcp/auth/oauth.py
+++ b/metamcp/auth/oauth.py
@@ -12,7 +12,7 @@ from typing import Any
 from urllib.parse import urlencode
 
 import httpx
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 from ..config import get_settings
 from ..exceptions import MetaMCPException
@@ -34,10 +34,9 @@ class OAuthProvider(BaseModel):
     scopes: list[str] = Field(default=["openid", "email", "profile"])
     redirect_uri: str = Field(..., description="Redirect URI")
 
-    class Config:
-        """Pydantic configuration."""
-
-        extra = "forbid"
+    model_config = {
+        "extra": "forbid"
+    }
 
 
 class OAuthToken(BaseModel):

--- a/metamcp/composition/models.py
+++ b/metamcp/composition/models.py
@@ -124,10 +124,9 @@ class WorkflowDefinition(BaseModel):
     )
     security_level: str = Field("medium", description="Security level")
 
-    class Config:
-        """Pydantic configuration."""
-
-        arbitrary_types_allowed = True
+    model_config = {
+        "arbitrary_types_allowed": True
+    }
 
 
 class WorkflowExecutionRequest(BaseModel):

--- a/metamcp/config.py
+++ b/metamcp/config.py
@@ -9,7 +9,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
-from pydantic import Field, validator
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 
 
@@ -195,7 +195,8 @@ class Settings(BaseSettings):
         description="Microsoft OAuth userinfo URL",
     )
 
-    @validator("environment")
+    @field_validator("environment")
+    @classmethod
     def validate_environment(cls, v):
         """Validate environment setting."""
         allowed = ["development", "staging", "production"]
@@ -203,7 +204,8 @@ class Settings(BaseSettings):
             raise ValueError(f"Environment must be one of {allowed}")
         return v
 
-    @validator("log_level")
+    @field_validator("log_level")
+    @classmethod
     def validate_log_level(cls, v):
         """Validate log level setting."""
         allowed = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
@@ -211,7 +213,8 @@ class Settings(BaseSettings):
             raise ValueError(f"Log level must be one of {allowed}")
         return v.upper()
 
-    @validator("log_format")
+    @field_validator("log_format")
+    @classmethod
     def validate_log_format(cls, v):
         """Validate log format setting."""
         allowed = ["json", "text"]
@@ -219,12 +222,11 @@ class Settings(BaseSettings):
             raise ValueError(f"Log format must be one of {allowed}")
         return v
 
-    class Config:
-        """Pydantic configuration."""
-
-        env_file = ".env"
-        env_file_encoding = "utf-8"
-        case_sensitive = False
+    model_config = {
+        "env_file": ".env",
+        "env_file_encoding": "utf-8",
+        "case_sensitive": False,
+    }
 
 
 # Global settings instance


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Migrate Pydantic models from V1 to V2 syntax to resolve warnings and improve test stability.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This change addresses Pydantic V1 to V2 migration warnings by updating `Config` classes to `model_config` and `@validator` decorators to `@field_validator`, as the first step in the overall test coverage improvement plan.

---

[Open in Web](https://cursor.com/agents?id=bc-ea12417e-416f-402e-8589-049624f1de9e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ea12417e-416f-402e-8589-049624f1de9e) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)